### PR TITLE
Install roles in current dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a work in progress, and is mostly a means for me to document my current 
   1. [Install Ansible](http://docs.ansible.com/intro_installation.html).
   2. Ensure Apple's command line tools are installed (`xcode-select --install` to launch the installer).
   3. Clone this repository to your local drive.
-  4. Run the command `$ ansible-galaxy install -r requirements.txt` inside this directory to install required Ansible roles.
+  4. Run the command `$ ansible-galaxy install -r requirements.txt -p .` inside this directory to install required Ansible roles.
   5. Run `ansible-playbook main.yml -i inventory --ask-sudo-pass` from the same directory as this README file.
 
 ## Included Applications / Configuration


### PR DESCRIPTION
`ansible-galaxy` install roles to `/etc/ansible/roles` by default, which required root access of system.

```
$ ansible-galaxy install -r requirements.txt
- downloading role 'dotfiles', owned by geerlingguy
- downloading role from https://github.com/geerlingguy/ansible-role-dotfiles/archive/1.0.0.tar.gz
- extracting geerlingguy.dotfiles to /etc/ansible/roles/geerlingguy.dotfiles
- error: you do not have permission to modify files in /etc/ansible/roles/geerlingguy.dotfiles
- geerlingguy.dotfiles was NOT installed successfully.
- you can use --ignore-errors to skip failed roles.
```

This PR changes this behaviour to install roles in current directory with `-p .`.