### PR TITLE
Removed Skitch from the list of apps only available from the app store

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ I also use the following apps at least once or twice per week, but unfortunately
   - Tweetbot
   - RadarScope
   - Pixelmator
-  - Skitch
   - Quick Resizer
   - 1Password
   - DaisyDisk


### PR DESCRIPTION
Delightfully, the way you have the homebrew role set up actually does install Skitch.