### PR TITLE
Add variables to skip the app preferences task and OSX config task

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -2,6 +2,8 @@
 downloads: ~/.ansible-downloads/
 
 configure_sudoers: yes
+configure_prefs: yes
+configure_osx: yes
 
 dotfiles_repo: https://github.com/geerlingguy/dotfiles.git
 dotfiles_repo_accept_hostkey: yes

--- a/main.yml
+++ b/main.yml
@@ -19,8 +19,10 @@
   tasks:
     - include: tasks/ansible-setup.yml
     - include: tasks/preferences.yml
+      when: configure_prefs
 
     # TODO: Use sudo once .osx can be run via root with no user interaction.
     - name: Run .osx dotfiles.
       shell: ~/.osx --no-restart
       changed_when: false
+      when: configure_osx


### PR DESCRIPTION
Thanks for sharing this solution to setting up your dev env.  My PR should be straight forward to understand based on the diff.

I added variables 'configure_prefs' and 'configure_osx' which correspond to a conditional when clause on the task which includes the preferences.yml tasks and the task which executes the .osx shell script, respectively.  

I liked that you provided a way to override in the config.yml whether the sudoers file gets configured, but saw there was lacking a way to skip these tasks.

If you decide to accept this PR, feel free to rename the variables to your liking- I tried to be consistent with your existing conventions.