### PR TITLE
Use mas_installed_apps vs mas_installed_app_ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ You can override any of the defaults configured in `default.config.yml` by creat
       - cowsay
       - git
       - go
-    
-    mas_installed_app_ids:
-      - 443987910 # 1Password
-      - 498486288 # Quick Resizer
-      - 557168941 # Tweetbot
-      - 497799835 # Xcode
+
+    mas_installed_apps:
+      - { id: 443987910, name: "1Password" }
+      - { id: 498486288, name: "Quick Resizer" }
+      - { id: 557168941, name: "Tweetbot" }
+      - { id: 497799835, name: "Xcode" }
 
 Any variable can be overridden in `config.yml`; see the supporting roles' documentation for a complete list of available variables.
 

--- a/default.config.yml
+++ b/default.config.yml
@@ -73,6 +73,6 @@ homebrew_cask_apps:
   - virtualbox
 
 # See `geerlingguy.mas` role documentation for usage instructions.
-mas_installed_app_ids: []
+mas_installed_apps: []
 mas_email: ""
 mas_password: ""

--- a/main.yml
+++ b/main.yml
@@ -14,7 +14,7 @@
     - geerlingguy.homebrew
     - geerlingguy.dotfiles
     - name: geerlingguy.mas
-      when: mas_installed_app_ids
+      when: mas_installed_apps
 
   tasks:
     - include: tasks/ansible-setup.yml


### PR DESCRIPTION
The `app_ids` flavor is deprecated: https://github.com/geerlingguy/ansible-role-mas/blob/master/defaults/main.yml#L4