### PR TITLE
Issue #36: Add option to install npm/composer/pip/gem packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,19 @@ You can override any of the defaults configured in `default.config.yml` by creat
       - { id: 497799835, name: "Xcode" }
 
     composer_packages:
-      - hirak/prestissimo
+      - name: hirak/prestissimo
       - name: drush/drush
         version: '^8.1'
 
     gem_packages:
       - name: bundler
         state: latest
+
+    npm_packages:
+      - name: webpack
+
+    pip_packages:
+      - name: mkdocs
 
 Any variable can be overridden in `config.yml`; see the supporting roles' documentation for a complete list of available variables.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is a work in progress, and is mostly a means for me to document my current 
 
 ### Running a specific set of tagged tasks
 
-You can filter which part of the provisioning process to run by specifying a set of tags using `ansible-playbook`'s `--tags` flag. The tags available are `dotfiles`, `homebrew`, `mas` and `osx`.
+You can filter which part of the provisioning process to run by specifying a set of tags using `ansible-playbook`'s `--tags` flag. The tags available are `dotfiles`, `homebrew`, `mas`, `extra-packages` and `osx`.
 
     ansible-playbook main.yml -i inventory -K --tags "dotfiles,homebrew"
 
@@ -45,6 +45,15 @@ You can override any of the defaults configured in `default.config.yml` by creat
       - { id: 498486288, name: "Quick Resizer" }
       - { id: 557168941, name: "Tweetbot" }
       - { id: 497799835, name: "Xcode" }
+
+    composer_packages:
+      - hirak/prestissimo
+      - name: drush/drush
+        version: '^8.1'
+
+    gem_packages:
+      - name: bundler
+        state: latest
 
 Any variable can be overridden in `config.yml`; see the supporting roles' documentation for a complete list of available variables.
 

--- a/default.config.yml
+++ b/default.config.yml
@@ -79,9 +79,21 @@ osx_script: "~/.osx --no-restart"
 # Note: You are responsible for making sure the required package managers are
 # installed, eg. through homebrew.
 composer_packages: []
+  # - name: drush
+  #   state: present # present/absent, default: present
+  #   version: "^8.1" # default: N/A
 gem_packages: []
+  # - name: bundler
+  #   state: present # present/absent/latest, default: present
+  #   version: "~> 1.15.1" # default: N/A
 npm_packages: []
+  # - name: webpack
+  #   state: present # present/absent/latest, default: present
+  #   version: "^2.6" # default: N/A
 pip_packages: []
+  # - name: mkdocs
+  #   state: present # present/absent/latest, default: present
+  #   version: "0.16.3" # default: N/A
 
 # Glob pattern to ansible task files to run after all other tasks are finished.
 post_provision_tasks: []

--- a/default.config.yml
+++ b/default.config.yml
@@ -75,5 +75,13 @@ mas_password: ""
 
 osx_script: "~/.osx --no-restart"
 
+# Install packages from other package managers.
+# Note: You are responsible for making sure the required package managers are
+# installed, eg. through homebrew.
+composer_packages: []
+gem_packages: []
+npm_packages: []
+pip_packages: []
+
 # Glob pattern to ansible task files to run after all other tasks are finished.
 post_provision_tasks: []

--- a/main.yml
+++ b/main.yml
@@ -33,6 +33,9 @@
       when: configure_osx
       tags: ['osx']
 
+    - include: tasks/extra-packages.yml
+      tags: ['extra-packages']
+
     - name: Run configured post-provision ansible task files.
       include: "{{ outer_item }}"
       loop_control:

--- a/tasks/extra-packages.yml
+++ b/tasks/extra-packages.yml
@@ -1,0 +1,31 @@
+---
+- name: Install global Composer packages.
+  composer:
+    command: "{{ (item.state | default('present') == 'absent') | ternary('remove', 'require') }}"
+    arguments: "{{ item.name | default(item) }} {{ item.version | default('@stable') }}"
+    # Ansible 2.4 supports `global_command` making `working_dir` optional.
+    working_dir: "{{ lookup('env', 'COMPOSER_HOME') | default('~/.composer', true) }}"
+  with_items: "{{ composer_packages }}"
+
+- name: Install global NPM packages.
+  npm:
+    name: "{{ item.name | default(item) }}"
+    version: "{{ item.version | default('latest') }}"
+    state: "{{ item.state | default('present') }}"
+    global: yes
+  with_items: "{{ npm_packages }}"
+
+- name: Install global Pip packages.
+  pip:
+    name: "{{ item.name | default(item) }}"
+    version: "{{ item.version | default(omit) }}"
+    state: "{{ item.state | default('latest') }}"
+  with_items: "{{ pip_packages }}"
+
+- name: Install global Ruby gems.
+  gem:
+    name: "{{ item.name | default(item) }}"
+    version: "{{ item.version | default(omit) }}"
+    state: "{{ item.state | default('latest') }}"
+    user_install: false
+  with_items: "{{ gem_packages }}"

--- a/tasks/extra-packages.yml
+++ b/tasks/extra-packages.yml
@@ -13,6 +13,7 @@
     version: "{{ item.version | default('latest') }}"
     state: "{{ item.state | default('present') }}"
     global: yes
+    executable: "{{ item.executable | default(omit) }}"
   with_items: "{{ npm_packages }}"
 
 - name: Install global Pip packages.
@@ -20,6 +21,7 @@
     name: "{{ item.name | default(item) }}"
     version: "{{ item.version | default(omit) }}"
     state: "{{ item.state | default('latest') }}"
+    executable: "{{ item.executable | default(omit) }}"
   with_items: "{{ pip_packages }}"
 
 - name: Install global Ruby gems.
@@ -28,4 +30,5 @@
     version: "{{ item.version | default(omit) }}"
     state: "{{ item.state | default('latest') }}"
     user_install: false
+    executable: "{{ item.executable | default(omit) }}"
   with_items: "{{ gem_packages }}"

--- a/tasks/extra-packages.yml
+++ b/tasks/extra-packages.yml
@@ -10,8 +10,8 @@
 - name: Install global NPM packages.
   npm:
     name: "{{ item.name | default(item) }}"
-    version: "{{ item.version | default('latest') }}"
     state: "{{ item.state | default('present') }}"
+    version: "{{ item.version | default(omit) }}"
     global: yes
     executable: "{{ item.executable | default(omit) }}"
   with_items: "{{ npm_packages }}"
@@ -19,16 +19,16 @@
 - name: Install global Pip packages.
   pip:
     name: "{{ item.name | default(item) }}"
+    state: "{{ item.state | default('present') }}"
     version: "{{ item.version | default(omit) }}"
-    state: "{{ item.state | default('latest') }}"
     executable: "{{ item.executable | default(omit) }}"
   with_items: "{{ pip_packages }}"
 
 - name: Install global Ruby gems.
   gem:
     name: "{{ item.name | default(item) }}"
+    state: "{{ item.state | default('present') }}"
     version: "{{ item.version | default(omit) }}"
-    state: "{{ item.state | default('latest') }}"
-    user_install: false
+    user_install: no
     executable: "{{ item.executable | default(omit) }}"
   with_items: "{{ gem_packages }}"


### PR DESCRIPTION
Notes:
- As of Ansible 2.4 we can use `global_command` instead of specifying the `working_dir`. 
- Users who want to access Composer bins need to make sure `composer global config bin-dir --absolute` is available in their `$PATH`. https://github.com/geerlingguy/dotfiles/ does this.
- I avoided any complicated module arguments and normalized everything to `item`, `version` and `state`.

Example:

```yaml
composer_packages:
  - hirak/prestissimo
  - name: drush/drush
    version: '^8.1'
```