### PR TITLE
Rename npm -> node

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -33,7 +33,7 @@ homebrew_installed_packages:
   - sqlite
   - mcrypt
   - nmap
-  - npm
+  - node
   - nvm
   - ssh-copy-id
   - cowsay


### PR DESCRIPTION
I found this a bit confusing when I first saw it.

I can't for the life of me find the why but `brew info npm` is identical to `brew info node`. There must be an alias defined somewhere there... I guess this was the way to do it before `node` bundled `npm`.

```
$ brew info npm
node: stable 8.0.0 (bottled), HEAD
Platform built on V8 to build network applications
https://nodejs.org/
Conflicts with: node@0.10, node@0.12
/usr/local/Cellar/node/7.10.0 (3,078 files, 39.7MB) *
  Poured from bottle on 2017-05-07 at 20:05:13
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/node.rb
==> Dependencies
Build: pkg-config ✔
Recommended: icu4c ✔
Optional: openssl ✔
==> Options
--with-debug
	Build with debugger hooks
--with-openssl
	Build against Homebrew's OpenSSL instead of the bundled OpenSSL
--without-completion
	npm bash completion will not be installed
--without-icu4c
	Build with small-icu (English only) instead of system-icu (all locales)
--without-npm
	npm will not be installed
--HEAD
	Install HEAD version
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
```