### PR TITLE
Fix syntax warnings

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -22,23 +22,23 @@
       tags: ['mas']
 
   tasks:
-    - include: tasks/ansible-setup.yml
+    - include_tasks: tasks/ansible-setup.yml
 
-    - include: tasks/sudoers.yml
+    - include_tasks: tasks/sudoers.yml
       when: configure_sudoers
 
-    - include: tasks/terminal.yml
+    - include_tasks: tasks/terminal.yml
       when: configure_terminal
 
-    - include: tasks/osx.yml
+    - include_tasks: tasks/osx.yml
       when: configure_osx
       tags: ['osx']
 
-    - include: tasks/extra-packages.yml
+    - include_tasks: tasks/extra-packages.yml
       tags: ['extra-packages']
 
     - name: Run configured post-provision ansible task files.
-      include: "{{ outer_item }}"
+      include_tasks: "{{ outer_item }}"
       loop_control:
         loop_var: outer_item
       with_fileglob: "{{ post_provision_tasks|default(omit) }}"


### PR DESCRIPTION
This resolves [`$ ansible-playbook main.yml --syntax-check`](https://travis-ci.org/geerlingguy/mac-dev-playbook/builds/322327246#L927) says `[DEPRECATION WARNING]` 

It requires include_tasks instead of [import_tasks](https://docs.ansible.com/ansible/2.4/import_tasks_module.html#options)
> Any loops, conditionals and most other keywords will be applied to the included tasks