### PR TITLE
Use absolute rather than relative path for config.yml

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -8,7 +8,7 @@
   pre_tasks:
     - include_vars: "{{ item }}"
       with_fileglob:
-        - ../config.yml
+        - "{{ playbook_dir }}/config.yml"
       tags: ['always']
 
   roles:


### PR DESCRIPTION
The relative path is relative to the files/ directory and so the include breaks if that directory is deleted.

https://groups.google.com/forum/#!topic/ansible-project/MzSZLYhx5AY

Therefore seems more robust to switch to an absolute path making use of`playbook_dir`.