### PR TITLE
Use osx_defaults module for part of .osx provisioning

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -71,6 +71,7 @@ mas_email: ""
 mas_password: ""
 
 osx_script: "~/.osx --no-restart"
+osx_legacy: true
 osx_defaults: []
 
 # Install packages from other package managers.

--- a/default.config.yml
+++ b/default.config.yml
@@ -71,6 +71,7 @@ mas_email: ""
 mas_password: ""
 
 osx_script: "~/.osx --no-restart"
+osx_defaults: []
 
 # Install packages from other package managers.
 # Note: You are responsible for making sure the required package managers are

--- a/default.config.yml
+++ b/default.config.yml
@@ -71,7 +71,8 @@ mas_email: ""
 mas_password: ""
 
 osx_script: "~/.osx --no-restart"
-osx_legacy: true
+osx_use_dotfile: true
+osx_use_defaults: false
 osx_defaults: []
 
 # Install packages from other package managers.

--- a/tasks/osx.yml
+++ b/tasks/osx.yml
@@ -1,5 +1,5 @@
 ---
-- name: Run .osx defaults.
+- name: Run macOS defaults.
   osx_defaults:
     domain: "{{ item.domain }}"
     key: "{{ item.key }}"
@@ -7,9 +7,9 @@
     value: "{{ item.value }}"
     state: "{{ item.state | default('present') }}"
   with_items: "{{ osx_defaults }}"
-  when: not osx_legacy
+  when: osx_use_defaults
 
-- name: Run legacy .osx dotfiles.
+- name: Run .osx dotfiles.
   shell: "{{ osx_script }}"
   changed_when: false
-  when: osx_legacy
+  when: osx_use_dotfile

--- a/tasks/osx.yml
+++ b/tasks/osx.yml
@@ -1,5 +1,9 @@
 ---
-# TODO: Use sudo once .osx can be run via root with no user interaction.
-- name: Run .osx dotfiles.
-  shell: "{{ osx_script }}"
-  changed_when: false
+- name: Run .osx defaults
+  osx_defaults:
+    domain: "{{ item.domain }}"
+    key: "{{ item.key }}"
+    type: "{{ item.type }}"
+    value: "{{ item.value }}"
+    state: "{{ item.state | default('present') }}"
+  with_items: "{{ osx_defaults }}"

--- a/tasks/osx.yml
+++ b/tasks/osx.yml
@@ -1,5 +1,5 @@
 ---
-- name: Run .osx defaults
+- name: Run .osx defaults.
   osx_defaults:
     domain: "{{ item.domain }}"
     key: "{{ item.key }}"
@@ -7,3 +7,9 @@
     value: "{{ item.value }}"
     state: "{{ item.state | default('present') }}"
   with_items: "{{ osx_defaults }}"
+  when: not osx_legacy
+
+- name: Run legacy .osx dotfiles.
+  shell: "{{ osx_script }}"
+  changed_when: false
+  when: osx_legacy

--- a/tasks/osx.yml
+++ b/tasks/osx.yml
@@ -9,6 +9,7 @@
   with_items: "{{ osx_defaults }}"
   when: osx_use_defaults
 
+# TODO: Use sudo once .osx can be run via root with no user interaction.
 - name: Run .osx dotfiles.
   shell: "{{ osx_script }}"
   changed_when: false


### PR DESCRIPTION
I found it very weird that many people who provision their Macs using Ansible still use a bash script (the `.osx` dotfile) to set some settings. 

That's why I started looking into converting all of that into Ansible tasks, because replacing all bash scripts with Ansible seems to be a good thing to do.

At the moment this change allows to move all `defaults` commands from the `.osx` script to the `config.yml` for this playbook. Other parts of the `.osx` script will be harder to implement, because I did not find readily usable roles or modules for those yet.

This Task is configured by the variable `osx_defaults` and activated by setting `osx_use_defaults` to `true`. I have also added `osx_use_dotfile` to determine if the `.osx` script should be run. The default behaviour of the playbook should not have changed. So if you merge this and don't touch your custom config, everything should be the same as before.

The `osx_defaults` variable is a list of defaults that can be directly transcribed from the `defaults` command used in many `.osx` scripts, for example:

`defaults write NSGlobalDomain AppleInterfaceStyle -string "Dark"`

becomes

```
osx_defaults:
  - { domain: NSGlobalDomain, key: AppleInterfaceStyle, type: string, value: Dark }
```

Feel free to propose changes do this, including ideas about how to implement the commands `pmset`, `launchctl` and `tmutil` via Ansible.