### PR TITLE
Add tag inheritance to post-provision tasks

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -45,9 +45,10 @@
       when: configure_sublime
       tags: ['sublime-text']
 
-    - name: Run configured post-provision ansible task files.
-      include_tasks: "{{ outer_item }}"
-      loop_control:
-        loop_var: outer_item
-      with_fileglob: "{{ post_provision_tasks|default(omit) }}"
+    - block:
+      - name: Run configured post-provision ansible task files.
+        include_tasks: "{{ outer_item }}"
+        loop_control:
+          loop_var: outer_item
+        with_fileglob: "{{ post_provision_tasks|default(omit) }}"
       tags: ['post']


### PR DESCRIPTION
Imported tasks inherit tags but Included tasks don't. This leads to confusion because included tasks need to have an explicit tag added or they won't run.

This is the workaround provided and [documented](https://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html#tag-inheritance-for-includes-blocks-and-the-apply-keyword) by Ansible to add tag inheritance to included tasks.