### PR TITLE
Move to macOS-11 and macOS-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-10.15
+          - macos-12
+          - macos-11
 
     steps:
       - name: Check out the codebase.
@@ -51,7 +52,9 @@ jobs:
           sudo rm -rf /Applications/Google\ Chrome.app
 
       - name: Install test dependencies.
-        run: sudo pip3 install ansible
+        run: |
+          sudo pip3 install --upgrade pip
+          sudo pip3 install ansible
 
       - name: Set up the test environment.
         run: |


### PR DESCRIPTION
Since `macos-10.15` is now [deprecated](https://github.com/actions/runner-images/issues/5583) and will be fully unsupported by 1/12/2022, we need to upgrade the os.
From `macos-11` on, `sudo pip3 install ansible` fails without upgrading `pip`, so we need to do that first.