### PR TITLE
Add Apple formatting/erasure guide

### DIFF
--- a/full-mac-setup.md
+++ b/full-mac-setup.md
@@ -109,4 +109,4 @@ git clone git://github.com/scrooloose/nerdtree.git
     - Motion Plugins from ~/Movies/Motion
     - Final Cut Pro Text Styles in ~/Library/Application Support/Motion/Library/Text Styles
     - Sequel Ace shortcuts from ~/Library/Containers/com.sequel-ace.sequel-ace/Data/Library/Application\ Support/Sequel\ Ace/Data/Favorites.plist
-  - Follow Apple's guide (TODO)
+  - Follow Apple's guide [here](https://support.apple.com/en-au/HT212749)


### PR DESCRIPTION
I was looking through the repo and saw the "(TODO)" in the formatting section and thought I'd fill it in, I linked the official apple "Erase your Mac and reset it to factory settings" guide, assuming that's the one you wanted. (https://support.apple.com/en-au/HT212749)