### PR TITLE
Delete Firefox binary in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           sudo rm -rf /Applications/Firefox.app
           sudo rm -rf /Applications/Google\ Chrome.app
+          sudo rm -rf /usr/local/bin/firefox
 
       - name: Install test dependencies.
         run: |


### PR DESCRIPTION
Brew finds a firefox binary in `/usr/local/bin/firefox` and thus fails to install.

This fixes the run - although I am not sure if there are extra steps that should be taken.