### PR TITLE
do not run github actions if only markdown changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@
 name: CI
 'on':
   pull_request:
+    paths-ignore:
+      - '*.md' # Markdown docs need no linting/testing etc.
   push:
+    paths-ignore:
+      - '*.md'
     branches:
       - master
   schedule:


### PR DESCRIPTION
why:
* these docs only changes don't need to be tested
* running CI takes over 10 minutes, so this shaves that off

Note that the for the CI to skip, the PR must *only* have markdown files. If there is a README change but also a yaml change, the CI will still run (which is what you would want).

> When all the path names match patterns in paths-ignore, the workflow will not run. If any path names do not match patterns in paths-ignore, even if some path names match the patterns, the workflow will run.
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-excluding-paths
