### PR TITLE
feat(pipx): add native pipx support for python applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ npm_packages:
 pip_packages:
   - name: mkdocs
 
+pipx_packages:
+  - name: ntfy
+    backend: pip
+
 configure_dock: true
 dockitems_remove:
   - Launchpad

--- a/default.config.yml
+++ b/default.config.yml
@@ -104,9 +104,12 @@ pip_packages: []
 #   state: present # present/absent/latest, default: present
 #   version: "0.16.3" # default: N/A
 
+pipx_default_backend: pip
 pipx_packages: []
 # - name: ntfy
 #   state: present # present/absent/latest, default: present
+#   executable: pipx # default: pipx
+#   backend: pip # pip/uv, default: pipx_default_backend
 
 # Set to 'true' to configure Sublime Text.
 configure_sublime: false

--- a/default.config.yml
+++ b/default.config.yml
@@ -104,6 +104,10 @@ pip_packages: []
 #   state: present # present/absent/latest, default: present
 #   version: "0.16.3" # default: N/A
 
+pipx_packages: []
+# - name: ntfy
+#   state: present # present/absent/latest, default: present
+
 # Set to 'true' to configure Sublime Text.
 configure_sublime: false
 sublime_base_path: "~/Library/Application Support/Sublime Text"

--- a/tasks/extra-packages.yml
+++ b/tasks/extra-packages.yml
@@ -43,5 +43,8 @@
   community.general.pipx:
     name: "{{ item.name | default(item) }}"
     state: "{{ item.state | default('present') }}"
+    executable: "{{ item.executable | default('pipx') }}"
   loop: "{{ pipx_packages }}"
   when: pipx_packages | length > 0
+  environment:
+    PIPX_DEFAULT_BACKEND: "{{ item.backend | default(pipx_default_backend) }}"

--- a/tasks/extra-packages.yml
+++ b/tasks/extra-packages.yml
@@ -32,3 +32,16 @@
     user_install: false
     executable: "{{ item.executable | default(omit) }}"
   loop: "{{ gem_packages }}"
+
+- name: Ensure pipx is installed.
+  community.general.homebrew:
+    name: pipx
+    state: present
+  when: pipx_packages | length > 0
+
+- name: Install global Python applications via pipx.
+  community.general.pipx:
+    name: "{{ item.name | default(item) }}"
+    state: "{{ item.state | default('present') }}"
+  loop: "{{ pipx_packages }}"
+  when: pipx_packages | length > 0

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -13,3 +13,6 @@ homebrew_installed_packages:
 homebrew_cask_apps:
   - firefox
   - licecap
+
+pipx_packages:
+  - name: pycowsay


### PR DESCRIPTION
This PR adds native support for installing global Python applications via pipx. This resolves PEP 668 ('externally-managed-environment') errors on modern macOS/Homebrew setups.

Key changes:
- Added pipx_packages and pipx_default_backend to default.config.yml.
- Implemented new tasks in tasks/extra-packages.yml using the community.general.pipx module.
- Added support for custom executable and backend (e.g., uv) per package.
- Updated documentation and test configuration.