### PR TITLE
Add pipx support for installing Python applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ npm_packages:
 pip_packages:
   - name: mkdocs
 
+# pipx support requires community.general >= 5.5.0. Set `pipx_ensurepath: true` to run
+# `pipx ensurepath` and ensure pipx-installed apps are on PATH; use
+# `backend: uv` only with pipx >= 1.12.0.
+pipx_packages:
+  - cowsay
+  - name: ntfy
+    state: latest
+
 configure_dock: true
 dockitems_remove:
   - Launchpad
@@ -127,6 +135,7 @@ Packages (installed with Homebrew):
   - node
   - nvm
   - php
+  - pipx
   - ssh-copy-id
   - readline
   - openssl

--- a/default.config.yml
+++ b/default.config.yml
@@ -52,6 +52,7 @@ homebrew_installed_packages:
   - node
   - nvm
   - php
+  - pipx
   - pngpaste
   - ssh-copy-id
   - readline
@@ -103,6 +104,16 @@ pip_packages: []
 # - name: mkdocs
 #   state: present # present/absent/latest, default: present
 #   version: "0.16.3" # default: N/A
+
+pipx_executable: pipx
+pipx_default_backend: pip # Note: 'uv' backend requires pipx >= 1.12.0.
+pipx_ensurepath: false
+pipx_packages: []
+# - cowsay
+# - name: ntfy
+#   state: present # present/absent/latest, default: present
+#   executable: pipx # path/name of pipx binary, default: pipx_executable
+#   backend: pip # pip/uv (requires pipx >= 1.12.0), default: pipx_default_backend
 
 # Set to 'true' to configure Sublime Text.
 configure_sublime: false

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,3 +5,5 @@ roles:
 
 collections:
   - name: geerlingguy.mac
+  - name: community.general
+    version: ">=5.5.0"  # pipx module added in 3.8.0, but state: latest requires 5.5.0

--- a/tasks/extra-packages.yml
+++ b/tasks/extra-packages.yml
@@ -44,11 +44,11 @@
 
 - name: Install global Python applications via pipx.
   community.general.pipx:
-    name: "{{ item.name if item is mapping else item }}"
-    state: "{{ item.state | default('present', true) if item is mapping else 'present' }}"
-    executable: "{{ item.executable | default(pipx_executable, true) if item is mapping else pipx_executable }}"
-  loop: "{{ pipx_packages | default([], true) }}"
+    name: "{{ item.name | default(item) }}"
+    state: "{{ item.state | default('present') }}"
+    executable: "{{ item.executable | default(pipx_executable) }}"
+  loop: "{{ pipx_packages }}"
   loop_control:
-    label: "{{ item.name if item is mapping else item }}"
+    label: "{{ item.name | default(item) }}"
   environment:
-    PIPX_DEFAULT_BACKEND: "{{ item.backend | default(pipx_default_backend, true) if item is mapping else pipx_default_backend }}"
+    PIPX_DEFAULT_BACKEND: "{{ item.backend | default(pipx_default_backend) }}"

--- a/tasks/extra-packages.yml
+++ b/tasks/extra-packages.yml
@@ -32,3 +32,23 @@
     user_install: false
     executable: "{{ item.executable | default(omit) }}"
   loop: "{{ gem_packages }}"
+
+- name: Ensure pipx application directory is on PATH.
+  ansible.builtin.command:
+    argv:
+      - "{{ pipx_executable }}"
+      - ensurepath
+  register: pipx_ensurepath_result
+  changed_when: "'Success' in pipx_ensurepath_result.stdout"  # pipx outputs 'Success! ...' when PATH is modified; substring match covers the full message
+  when: pipx_ensurepath
+
+- name: Install global Python applications via pipx.
+  community.general.pipx:
+    name: "{{ item.name if item is mapping else item }}"
+    state: "{{ item.state | default('present', true) if item is mapping else 'present' }}"
+    executable: "{{ item.executable | default(pipx_executable, true) if item is mapping else pipx_executable }}"
+  loop: "{{ pipx_packages | default([], true) }}"
+  loop_control:
+    label: "{{ item.name if item is mapping else item }}"
+  environment:
+    PIPX_DEFAULT_BACKEND: "{{ item.backend | default(pipx_default_backend, true) if item is mapping else pipx_default_backend }}"

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -6,6 +6,7 @@ homebrew_installed_packages:
   - sqlite
   - ssh-copy-id
   - readline
+  - pipx
   - pv
   - wget
   - wrk
@@ -13,3 +14,9 @@ homebrew_installed_packages:
 homebrew_cask_apps:
   - firefox
   - licecap
+
+pipx_ensurepath: true
+
+pipx_packages:
+  - name: pycowsay
+  - cowsay


### PR DESCRIPTION
In the interest of full disclosure, I leveraged AI assistance for this PR; I'd classify it as "Level 6: Bots coded, human understands mostly" on the [VisiData scale](https://www.visidata.org/blog/2026/ai/). That said, I've put the changes through multiple rounds of code review using CodeRabbit, Gemini, cubic.dev, and Claude to achieve consensus.

[With Python 3.12](https://docs.brew.sh/Homebrew-and-Python), Homebrew began following [PEP 668](https://peps.python.org/pep-0668/#marking-an-interpreter-as-using-an-external-package-manager) and [recommends using pipx](https://docs.brew.sh/Homebrew-and-Python) to install Python CLI applications in isolated virtual environments.

This PR adds `pipx` support, following the pattern used for npm, pip, gem, and composer packages. It adds:

- `pipx_packages`: list of applications to install via `pipx`, supporting both simple strings (`- ntfy`) and dicts with per-item overrides (`state`, `executable`, `backend`)
- `pipx_ensurepath`: opt-in flag to run `pipx ensurepath` and add the pipx bin directory to `PATH` (defaults to `false`)
- `pipx_executable` and `pipx_default_backend`: playbook-wide defaults for the pipx binary and package backend (`pip` or `uv`)
- `pipx` added to `homebrew_installed_packages` so it's present before the tasks run
- `community.general >= 5.5.0` added to `requirements.yml` (the `pipx` module was introduced in 3.8.0, but `state: latest` requires 5.5.0)

All new variables default to empty lists or `false` to avoid impacting existing users.

NOTE: existing tasks in extra-packages.yml use short module names (pip, gem, etc.); the new tasks use fully-qualified names (ansible.builtin.command, community.general.pipx). The FQCN is required for the community.general module and used on the command task for consistency, but I can align those to short names if you'd prefer uniformity.